### PR TITLE
Streamline versioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,10 @@
   <PropertyGroup Condition=" '$(Configuration)' != 'Debug' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyVersion>0.0.13</AssemblyVersion>
+    <ApplicationVersion>0.0.13</ApplicationVersion>
+    <Version>0.0.13</Version>
+    <FileVersion>0.0.13</FileVersion>
+  </PropertyGroup>
 </Project>

--- a/scripts/bump.fsx
+++ b/scripts/bump.fsx
@@ -4,7 +4,7 @@ open System
 open System.Linq
 open System.IO
 
-#r "nuget: Fsdk, 0.6.0--date20230502-0946.git-f0c1aee"
+#r "nuget: Fsdk, 0.6.0--date20230602-0434.git-ad36c88"
 
 open Fsdk
 open Fsdk.Process
@@ -49,8 +49,7 @@ let filesToBumpFullVersion: seq<FileInfo> =
     Seq.append
         filesToBumpMiniVersion
         [
-            Path.Combine(rootDir.FullName, "src/Frontend/Frontend.csproj")
-            |> FileInfo
+            Path.Combine(rootDir.FullName, "Directory.Build.props") |> FileInfo
             Path.Combine(
                 rootDir.FullName,
                 "src/Frontend/Platforms/iOS/Info.plist"

--- a/src/Frontend/Frontend.csproj
+++ b/src/Frontend/Frontend.csproj
@@ -17,9 +17,6 @@
 		<!-- App Identifier -->
 		<ApplicationId>com.nodeffect.dg</ApplicationId>
 
-		<!-- Versions -->
-		<ApplicationVersion>0.0.13</ApplicationVersion>
-
 		<!-- Required for C# Hot Reload -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
 

--- a/tests/Backend.Tests/Marshalling.fs
+++ b/tests/Backend.Tests/Marshalling.fs
@@ -10,7 +10,7 @@ let Setup() =
     ()
 
 let serializedLocationUpdateReq =
-    "{\"Version\":\"1.0.0.0\",\"TypeName\":\"DataModel.UpdateGpsLocationRequest\",\"Value\":"
+    $"{{\"Version\":\"{VersionHelper.CURRENT_VERSION}\",\"TypeName\":\"DataModel.UpdateGpsLocationRequest\",\"Value\":"
     + "{\"UserId\":1,\"Latitude\":6,\"Longitude\":9}}"
 
 let updateGpsLocationRequest =


### PR DESCRIPTION
JSON objects were showing a dumb '1.0.0.0' version;
to fix this we needed to define `<AssemblyVersion>`
tag in DataModel project; however we decided to
put it in Directory.Build.props (so that it affects
all projects), and also bring more version tags
(because why not?), one of them which was already
existing in Frontend project.