### PR TITLE
Frontend: add Styles.xaml for dynamic theme swap

### DIFF
--- a/src/Frontend/App.xaml
+++ b/src/Frontend/App.xaml
@@ -7,6 +7,15 @@
     windows:Application.ImageDirectory="Assets"
 >
     <Application.Resources>
-        <ResourceDictionary />
+        <ResourceDictionary>
+            <!-- Workaround: Styles.xaml and Colors.xaml are added as an workaround for dynamic theme change problems
+                which are stated in the following issue: https://github.com/dotnet/maui/issues/15359 . This workaround
+                can be removed after the PR https://github.com/dotnet/maui/pull/15449 is merged. -->
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <!-- End of Workaround -->
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Frontend/MauiProgram.cs
+++ b/src/Frontend/MauiProgram.cs
@@ -35,6 +35,17 @@ public static class MauiProgram
             cfg["ApiKey"]
         ));
 #endif
+
+        // We have to add these mappings to fix the border color of text input widgets (Picker, Entry, Editor)
+        // when the android theme changes when the app is open (issue: https://github.com/dotnet/maui/issues/15359).
+        // We have to add this because in the current version of Maui, there are problems with dynamic app theme
+        // change. In the future once the following PR is merged (PR: https://github.com/dotnet/maui/pull/15449)
+        // and released, we'll be able to remove this workaround.
+        // Once PR is merged, Platforms/Android/AndroidExtraMappers.cs file can be removed.
+#if ANDROID
+        AndroidExtraMappers.AddMappers();
+#endif
+
         return builder.Build();
     }
 }

--- a/src/Frontend/Platforms/Android/AndroidExtraMappers.cs
+++ b/src/Frontend/Platforms/Android/AndroidExtraMappers.cs
@@ -1,0 +1,43 @@
+﻿using Android.Graphics;
+using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+namespace Frontend;
+
+
+static class AndroidExtraMappers
+{
+    static private void MapTextColorToBorderColor(IViewHandler handler, Android.Graphics.Color color)
+    {
+        if (handler.PlatformView is AppCompatEditText editText)
+        {
+            var colorFilter = new PorterDuffColorFilter(color, PorterDuff.Mode.SrcAtop);
+            editText.Background.SetColorFilter(colorFilter);
+        }
+    }
+
+    static internal void AddMappers()
+    {
+        EntryHandler.Mapper.AppendToMapping(
+            "TextColor",
+            (IEntryHandler handler, IEntry view) => {
+                MapTextColorToBorderColor(handler, view.TextColor.ToPlatform());
+            }
+        );
+
+        EditorHandler.Mapper.AppendToMapping(
+            "TextColor",
+            (IEditorHandler handler, IEditor view) => {
+                MapTextColorToBorderColor(handler, view.TextColor.ToPlatform());
+            }
+        );
+
+        PickerHandler.Mapper.AppendToMapping(
+            "TextColor",
+            (IPickerHandler handler, IPicker view) => {
+                MapTextColorToBorderColor(handler, view.TextColor.ToPlatform());
+            }
+        );
+    }
+}

--- a/src/Frontend/Resources/Styles/Colors.xaml
+++ b/src/Frontend/Resources/Styles/Colors.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+>
+    <Color x:Key="Primary">#2D3E50</Color>
+    <Color x:Key="Secondary">#2D3E50</Color>
+    <Color x:Key="White">White</Color>
+    <Color x:Key="Black">Black</Color>
+    <Color x:Key="Gray200">#C8C8C8</Color>
+    <Color x:Key="Gray600">#404040</Color>
+    <Color x:Key="Gray900">#212121</Color>
+    <Color x:Key="Gray950">#141414</Color>
+    <Color x:Key="Blue">#4792d7</Color>
+</ResourceDictionary>

--- a/src/Frontend/Resources/Styles/Styles.xaml
+++ b/src/Frontend/Resources/Styles/Styles.xaml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+>
+    <Style TargetType="Button">
+        <Setter
+            Property="TextColor"
+            Value="{OnPlatform Android = {StaticResource White}, iOS = {StaticResource Blue}}"
+        />
+        <Setter
+            Property="BackgroundColor"
+            Value="{OnPlatform Android ={StaticResource Primary}, iOS=Transparent}"
+        />
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter
+                                Property="TextColor"
+                                Value="{OnPlatform Android = {AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}, iOS={AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}}"
+                            />
+                            <Setter
+                                Property="BackgroundColor"
+                                Value="{OnPlatform Android = {AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}, iOS =Transparent}"
+                            />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style TargetType="Entry">
+        <Setter
+            Property="TextColor"
+            Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+        />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+    </Style>
+
+    <Style TargetType="Editor">
+        <Setter
+            Property="TextColor"
+            Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+        />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter
+            Property="TextColor"
+            Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}"
+        />
+    </Style>
+
+    <Style TargetType="Picker">
+        <Setter
+            Property="TextColor"
+            Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}"
+        />
+        <Setter
+            Property="TitleColor"
+            Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}"
+        />
+    </Style>
+
+    <Style TargetType="Page" ApplyToDerivedTypes="True">
+        <Setter Property="Padding" Value="0" />
+        <Setter
+            Property="BackgroundColor"
+            Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}"
+        />
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
Add minimal Styles.xaml to workaround dynamic theme change problems [1]. Also add mappers to map text color to border color for text entry widgets. These workarounds can be removed after the PR [2] is merged and released.

[1] https://github.com/dotnet/maui/issues/15359
[2] https://github.com/dotnet/maui/pull/15449